### PR TITLE
Fixed implementation of conversion to std::fs::File

### DIFF
--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -67,6 +67,10 @@ impl Drop for PipeReader {
 impl From<PipeReader> for std::fs::File {
     fn from(pipe: PipeReader) -> Self {
         use std::os::windows::io::FromRawHandle;
+        // If we wouldn't wrap the reader in `ManuallyDrop` 
+        // the handle would be closed before the function 
+        // returned making the handle invalid.
+        let pipe = std::mem::ManuallyDrop::new(pipe);
         unsafe { std::fs::File::from_raw_handle(pipe.handle.0 as _) }
     }
 }

--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -54,6 +54,10 @@ impl Drop for PipeWriter {
 impl From<PipeWriter> for std::fs::File {
     fn from(pipe: PipeWriter) -> Self {
         use std::os::windows::io::FromRawHandle;
+        // If we wouldn't wrap the writer in `ManuallyDrop` 
+        // the handle would be closed before the function 
+        // returned making the handle invalid.
+        let pipe = std::mem::ManuallyDrop::new(pipe);
         unsafe { std::fs::File::from_raw_handle(pipe.handle.0 as _) }
     }
 }


### PR DESCRIPTION
The current implementation of the `From` trait for `PipeReader` and `PipeWriter` for `std::fs::File` is wrong, resulting in a `invalid handle` error whenever trying to use the produced file.

Rust makes it kind of hard to see why this is wrong, but I added a comment to explain the issue.