### PR TITLE
extend API to spawn process with specific initial terminal size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ mod process;
 mod util;
 
 pub use process::Process;
+pub use process::ProcessOptions;
 
 /// Spawns a command using `cmd.exe`.
 pub fn spawn(command: impl AsRef<OsStr>) -> Result<Process, Error> {


### PR DESCRIPTION
Hello,

I'm currently working on https://github.com/uutils/coreutils to provide a terminal simulation on the tests also for windows.
I decided to use `conpty` for this, but I stumbled accross the issue that there is no way to initially provide the desired terminal size.
It is important for us to change the terminal size from the default one.
`conpty` provides a `Process::resize` function that allows to change the terminal size after it has started.
But this I can't use because of two major issues:
1. it causes raise conditions as child process has already started and might have queried the terminal size already before it was changed.
2. it causes additianl ANSI-Escape sequences to appear for clearing the buffer and other stuff triggered by the resize.

Therefor I would like to introduce this change to `conpty`. 
I introduced an new function leaving the existing one untouched such that its backwards compatible.