### PR TITLE
upgrade windows crate to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["win32", "ConPTY", "terminal", "shell"]
 readme = "README.md"
 
 [dependencies.windows]
-version = "0.44.0"
+version = "0.54.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/src/console.rs
+++ b/src/console.rs
@@ -59,10 +59,10 @@ impl Console {
         set_raw_stdin(self.stdin, self.stdin_mode)?;
 
         unsafe {
-            SetConsoleMode(self.stdout, self.stdout_mode | DISABLE_NEWLINE_AUTO_RETURN).ok()?;
+            SetConsoleMode(self.stdout, self.stdout_mode | DISABLE_NEWLINE_AUTO_RETURN)?;
         }
         unsafe {
-            SetConsoleMode(self.stderr, self.stderr_mode | DISABLE_NEWLINE_AUTO_RETURN).ok()?;
+            SetConsoleMode(self.stderr, self.stderr_mode | DISABLE_NEWLINE_AUTO_RETURN)?;
         }
 
         Ok(())
@@ -71,7 +71,7 @@ impl Console {
     /// Sets terminal in a mode which was initially used on handles.
     pub fn reset(&self) -> Result<(), Error> {
         for (handle, mode) in self.streams() {
-            unsafe { SetConsoleMode(handle, mode).ok()? };
+            unsafe { SetConsoleMode(handle, mode)? };
         }
 
         Ok(())
@@ -98,7 +98,7 @@ impl Console {
 fn get_console_mode(h: HANDLE) -> WinResult<CONSOLE_MODE> {
     let mut mode = CONSOLE_MODE::default();
     unsafe {
-        GetConsoleMode(h, &mut mode).ok()?;
+        GetConsoleMode(h, &mut mode)?;
     }
     Ok(mode)
 }
@@ -120,7 +120,7 @@ fn set_raw_stdin(stdin: HANDLE, mut mode: CONSOLE_MODE) -> WinResult<()> {
     }
 
     unsafe {
-        SetConsoleMode(stdin, mode).ok()?;
+        SetConsoleMode(stdin, mode)?;
     }
 
     Ok(())

--- a/src/process.rs
+++ b/src/process.rs
@@ -13,7 +13,7 @@ use std::{
 use windows::{
     core::{self as win, HRESULT, PCWSTR, PWSTR},
     Win32::{
-        Foundation::{CloseHandle, HANDLE, WAIT_TIMEOUT},
+        Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT},
         Storage::FileSystem::{
             CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
             FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
@@ -30,9 +30,8 @@ use windows::{
                 CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess, GetProcessId,
                 InitializeProcThreadAttributeList, TerminateProcess, UpdateProcThreadAttribute,
                 WaitForSingleObject, CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT,
-                LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, STARTUPINFOEXW,
+                INFINITE, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, STARTUPINFOEXW,
             },
-            WindowsProgramming::INFINITE,
         },
     },
 };
@@ -192,11 +191,11 @@ fn enableVirtualTerminalSequenceProcessing() -> win::Result<()> {
     let stdout_h = stdout_handle()?;
     unsafe {
         let mut mode = CONSOLE_MODE::default();
-        GetConsoleMode(stdout_h, &mut mode).ok()?;
+        GetConsoleMode(stdout_h, &mut mode)?;
         mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING; // DISABLE_NEWLINE_AUTO_RETURN
-        SetConsoleMode(stdout_h, mode).ok()?;
+        SetConsoleMode(stdout_h, mode)?;
 
-        CloseHandle(stdout_h).ok()?;
+        CloseHandle(stdout_h)?;
     }
 
     Ok(())
@@ -212,8 +211,8 @@ fn createPseudoConsole(size: COORD) -> win::Result<(HPCON, HANDLE, HANDLE)> {
     // because the handles are dup'ed into the ConHost and will be released
     // when the ConPTY is destroyed.
     unsafe {
-        CloseHandle(pty_in).ok()?;
-        CloseHandle(pty_out).ok()?;
+        CloseHandle(pty_in)?;
+        CloseHandle(pty_out)?;
     }
 
     Ok((console, con_reader, con_writer))
@@ -223,8 +222,8 @@ fn inhirentConsoleSize() -> win::Result<COORD> {
     let stdout_h = stdout_handle()?;
     let mut info = CONSOLE_SCREEN_BUFFER_INFO::default();
     unsafe {
-        GetConsoleScreenBufferInfo(stdout_h, &mut info).ok()?;
-        CloseHandle(stdout_h).ok()?;
+        GetConsoleScreenBufferInfo(stdout_h, &mut info)?;
+        CloseHandle(stdout_h)?;
     };
 
     let mut size = COORD { X: 24, Y: 80 };
@@ -245,10 +244,11 @@ fn initializeStartupInfoAttachedToConPTY(hPC: &mut HPCON) -> win::Result<STARTUP
     let res = unsafe {
         InitializeProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST(null_mut()), 1, 0, &mut size)
     };
-    if res.as_bool() || size == 0 {
+    if res.is_ok() /* according to the documentation this initial call must fail! */ || size == 0 {
+        // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-initializeprocthreadattributelist#return-value
         return Err(win::Error::new(
             HRESULT::default(),
-            "failed initialize proc attribute list".into(),
+            "failed initialize proc attribute list",
         ));
     }
 
@@ -261,7 +261,7 @@ fn initializeStartupInfoAttachedToConPTY(hPC: &mut HPCON) -> win::Result<STARTUP
     siEx.lpAttributeList = LPPROC_THREAD_ATTRIBUTE_LIST(lpAttributeList.as_mut_ptr() as _);
 
     unsafe {
-        InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &mut size).ok()?;
+        InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &mut size)?;
         UpdateProcThreadAttribute(
             siEx.lpAttributeList,
             0,
@@ -270,8 +270,7 @@ fn initializeStartupInfoAttachedToConPTY(hPC: &mut HPCON) -> win::Result<STARTUP
             size_of::<HPCON>(),
             None,
             None,
-        )
-        .ok()?;
+        )?;
     }
 
     Ok(siEx)
@@ -315,8 +314,7 @@ fn execProc(command: Command, startup_info: STARTUPINFOEXW) -> win::Result<PROCE
             current_dir,
             &startup_info.StartupInfo,
             &mut proc_info,
-        )
-        .ok()?
+        )?
     };
 
     Ok(proc_info)
@@ -337,7 +335,7 @@ fn build_commandline(command: &Command) -> OsString {
 fn pipe() -> win::Result<(HANDLE, HANDLE)> {
     let mut p_in = HANDLE::default();
     let mut p_out = HANDLE::default();
-    unsafe { CreatePipe(&mut p_in, &mut p_out, None, 0).ok()? };
+    unsafe { CreatePipe(&mut p_in, &mut p_out, None, 0)? };
 
     Ok((p_in, p_out))
 }
@@ -354,7 +352,7 @@ fn stdout_handle() -> win::Result<HANDLE> {
     unsafe {
         CreateFileW(
             conout,
-            FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+            (FILE_GENERIC_READ | FILE_GENERIC_WRITE).0,
             FILE_SHARE_READ | FILE_SHARE_WRITE,
             None,
             OPEN_EXISTING,
@@ -398,7 +396,7 @@ fn console_stdout_set_echo(on: bool) -> Result<(), Error> {
     let stdout_h = stdout_handle()?;
 
     let mut mode = CONSOLE_MODE::default();
-    unsafe { GetConsoleMode(stdout_h, &mut mode).ok()? };
+    unsafe { GetConsoleMode(stdout_h, &mut mode)? };
 
     match on {
         true => mode |= ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT,
@@ -406,8 +404,8 @@ fn console_stdout_set_echo(on: bool) -> Result<(), Error> {
     };
 
     unsafe {
-        SetConsoleMode(stdout_h, mode).ok()?;
-        CloseHandle(stdout_h).ok()?;
+        SetConsoleMode(stdout_h, mode)?;
+        CloseHandle(stdout_h)?;
     }
 
     Ok(())
@@ -450,7 +448,7 @@ fn get_process_pid(proc: HANDLE) -> u32 {
 }
 
 fn kill_process(proc: HANDLE, code: u32) -> Result<(), Error> {
-    unsafe { TerminateProcess(proc, code).ok()? };
+    unsafe { TerminateProcess(proc, code)? };
     Ok(())
 }
 
@@ -467,14 +465,15 @@ fn wait_process(proc: HANDLE, timeout_millis: Option<u32>) -> Result<u32, Error>
                 return Err(Error::Timeout(Duration::from_millis(timeout as u64)));
             }
         }
-        None => {
-            unsafe { WaitForSingleObject(proc, INFINITE).ok()? };
-        }
+        None => match unsafe { WaitForSingleObject(proc, INFINITE) } {
+            WAIT_OBJECT_0 => {}
+            event_id => return Err(Error::WaitFailed(event_id)),
+        },
     }
 
     let mut code = 0;
     unsafe {
-        GetExitCodeProcess(proc, &mut code).ok()?;
+        GetExitCodeProcess(proc, &mut code)?;
     }
 
     Ok(code)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use windows::core as win;
 use windows::Win32::{
     Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE},
@@ -18,14 +16,8 @@ pub(crate) fn clone_handle(handle: HANDLE) -> win::Result<HANDLE> {
             0,
             false,
             DUPLICATE_SAME_ACCESS,
-        )
-        .ok()?;
+        )?;
     }
 
     Ok(cloned_handle)
-}
-
-pub(crate) fn win_error_to_io(err: windows::core::Error) -> io::Error {
-    let code = err.code();
-    io::Error::from_raw_os_error(code.0)
 }


### PR DESCRIPTION
I needed to use the windows crate in uutils directly as well to achieve the proper integration into the test framewort.
I realized that there is a newer window crate version available. To avoid that we have to link to two different versions. I would like to upgrade conpty-rs as well.