### PR TITLE
Add Send + Sync implementations to Process

### DIFF
--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -81,6 +81,9 @@ impl fmt::Debug for PipeReader {
     }
 }
 
+unsafe impl Send for PipeReader {}
+unsafe impl Sync for PipeReader {}
+
 fn pipe_available_bytes(h: HANDLE) -> io::Result<u32> {
     let mut bytes = MaybeUninit::<u32>::uninit();
     let bytes_ptr: *mut u32 = unsafe { ptr::addr_of_mut!(*bytes.as_mut_ptr()) };

--- a/src/io/writer.rs
+++ b/src/io/writer.rs
@@ -61,12 +61,15 @@ impl From<PipeWriter> for std::fs::File {
 
 impl fmt::Debug for PipeWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PipeReader")
+        f.debug_struct("PipeWriter")
             .field("handle", &(self.handle.0))
             .field("handle(ptr)", &(self.handle.0 as *const c_void))
             .finish()
     }
 }
+
+unsafe impl Send for PipeWriter {}
+unsafe impl Sync for PipeWriter {}
 
 fn write_to_pipe(h: HANDLE, buf: &[u8]) -> io::Result<usize> {
     let mut n = 0;

--- a/src/process.rs
+++ b/src/process.rs
@@ -190,6 +190,9 @@ impl fmt::Debug for Process {
     }
 }
 
+unsafe impl Send for Process {}
+unsafe impl Sync for Process {}
+
 fn enableVirtualTerminalSequenceProcessing() -> win::Result<()> {
     let stdout_h = stdout_handle()?;
     unsafe {


### PR DESCRIPTION
It looks like Process does not have `Send` or `Sync` implementations right now because it contains raw pointers. However, I think the way the crate uses these handles is thread-safe and can be `Send + Sync`. (Though I am not familiar with Windows concepts like HANDLE — I could be wrong!)

This PR adds the trait implementations for Process, as well as PipeReader and PipeWriter.