### PR TITLE
Implement Windows CI jobs (rustfmt + test)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  rustfmt:
+    name: Rust format
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: rustup toolchain install nightly --profile minimal -c rustfmt
+
+      - run: cargo +nightly fmt -- --check
+
+  rust:
+    name: Rust lint and test
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: rustup toolchain install stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo test
+
+      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,7 @@ jobs:
 
       - run: cargo test
 
-      - run: cargo clippy --all-targets -- -D warnings
+      # Unfortunately this code currently triggers a couple Clippy lints at the
+      # warn and error level, so the following line is commented out.
+      #
+      # - run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
This should automatically run `cargo test` on Windows on stable Rust whenever a push or PR is made to `master`. Since this is a public repository, [GitHub Actions is free](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).

I also have a line for `cargo clippy` lints in my CI template, you can enable it later if you like or remove it.